### PR TITLE
forked fuzzy wuzzy and removed a useless warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'fuzzywuzzy>=0.17.0',
+        'git+https://github.com/ArjixGamer/fuzzywuzzy',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'git://github.com/ArjixGamer/fuzzywuzzy.git',
+        'https://github.com/ArjixGamer/fuzzywuzzy/archive/master.zip',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'https://github.com/ArjixGamer/fuzzywuzzy/archive/master.zip',
+        'fuzzywuzzy@https://github.com/ArjixGamer/fuzzywuzzy/archive/master.zip',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'git+https://github.com/ArjixGamer/fuzzywuzzy',
+        'git+git://github.com/ArjixGamer/fuzzywuzzy.git',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'git+git://github.com/ArjixGamer/fuzzywuzzy.git',
+        'git+https://github.com/ArjixGamer/fuzzywuzzy.git',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'beautifulsoup4>=4.6.0',
         'requests>=2.18.4',
         'Click>=6.7',
-        'git+https://github.com/ArjixGamer/fuzzywuzzy.git',
+        'git://github.com/ArjixGamer/fuzzywuzzy.git',
         'coloredlogs>=10.0',
         'cfscrape>=2.0.5',
         'requests-cache>=0.4.13',


### PR DESCRIPTION
removed:
if platform.python_implementation() != "PyPy":
    warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')

now we dont get a warning that does nothing